### PR TITLE
/\d/ => /[0—9]/

### DIFF
--- a/Data/Lookup.pm
+++ b/Data/Lookup.pm
@@ -14,7 +14,7 @@ sub Reach {
         if(!defined $ptr) {return wantarray ? (0,undef) : 0}
 
         my $key = shift;
-        if($key =~ /^\d+$/) {
+        if($key =~ /^[0-9]+$/) {
             if(ref $ptr ne 'ARRAY' || !exists $ptr->[$key]) {return wantarray ? (0,undef) : 0}
             $ptr = $ptr->[$key];
         }


### PR DESCRIPTION
Avoid costly unicode lookups on utf8 keys